### PR TITLE
fix: allow empty -m for section deletion in edit-page

### DIFF
--- a/docs/README.agents.md
+++ b/docs/README.agents.md
@@ -78,3 +78,37 @@ npm install -g @andrzejchm/notion-cli
 curl -fsSL https://raw.githubusercontent.com/andrzejchm/notion-cli/main/docs/skills/using-notion-cli/SKILL.md \
   -o ~/.config/opencode/skills/using-notion-cli/SKILL.md
 ```
+
+---
+
+## Editing Gotchas
+
+### Table selector gotcha
+
+Tables written as markdown (`| Col | Col |`) are returned by Notion as `<table>` HTML. When building `--range` selectors for table content, use the HTML form from `read` output, not the markdown form you wrote.
+
+```bash
+# Read the page to see actual format
+notion read $PAGE_ID
+# Selector must match the returned format:
+notion edit-page $PAGE_ID --range "## Data...</table>" -m "## Data\n\n| Name | Score |\n|------|-------|\n| Alice | 100 |"
+```
+
+### Code block selector gotcha
+
+Triple backticks (`` ``` ``) appear twice in every code block (opening + closing). A selector like `` ```python...``` `` will match multiple occurrences. Include content from inside the code block to disambiguate:
+
+```bash
+# BAD: matches 2+ occurrences
+notion edit-page $PAGE_ID --range '```python...```' -m '...'
+# GOOD: include unique content inside the block
+notion edit-page $PAGE_ID --range '```python\ndef hello...print("world")\n```' -m '...'
+```
+
+### Deleting a section
+
+Use empty `-m ""` with `--range` and `--allow-deleting-content`:
+
+```bash
+notion edit-page $PAGE_ID --range "## Old Section...end of old section" -m "" --allow-deleting-content
+```

--- a/src/commands/edit-page.ts
+++ b/src/commands/edit-page.ts
@@ -52,10 +52,9 @@ export function editPageCommand(): Command {
         }
 
         let markdown = '';
-        if (opts.message) {
+        if (opts.message !== undefined) {
           markdown = opts.message;
         } else if (!process.stdin.isTTY) {
-          // Stricter than `append` — empty content would wipe the page, so we reject it.
           markdown = await readStdin();
           if (!markdown.trim()) {
             throw new CliError(
@@ -69,6 +68,15 @@ export function editPageCommand(): Command {
             ErrorCodes.INVALID_ARG,
             'No content provided.',
             'Pass markdown via -m/--message or pipe it through stdin',
+          );
+        }
+
+        // Reject empty content for full-page replace (would wipe the page)
+        if (!markdown.trim() && !opts.range) {
+          throw new CliError(
+            ErrorCodes.INVALID_ARG,
+            'Empty content would wipe the entire page.',
+            'Use --range to target a specific section, or provide non-empty content',
           );
         }
 

--- a/tests/commands/edit-page.test.ts
+++ b/tests/commands/edit-page.test.ts
@@ -258,6 +258,71 @@ describe('editPageCommand', () => {
     });
   });
 
+  describe('empty -m with --range (section deletion)', () => {
+    it('succeeds with empty -m when --range and --allow-deleting-content are set', async () => {
+      const cmd = editPageCommand();
+      await cmd.parseAsync([
+        'node',
+        'test',
+        'b55c9c91384d452b81dbd1ef79372b75',
+        '-m',
+        '',
+        '--range',
+        '## Old Section...end of old',
+        '--allow-deleting-content',
+      ]);
+
+      expect(mockReplaceMarkdown).toHaveBeenCalledWith(
+        expect.anything(),
+        'b55c9c91-384d-452b-81db-d1ef79372b75',
+        '',
+        { range: '## Old Section...end of old', allowDeletingContent: true },
+      );
+      expect(stdoutSpy).toHaveBeenCalledWith('Page content replaced.\n');
+    });
+
+    it('succeeds with empty -m when --range is set (without --allow-deleting-content)', async () => {
+      const cmd = editPageCommand();
+      await cmd.parseAsync([
+        'node',
+        'test',
+        'b55c9c91384d452b81dbd1ef79372b75',
+        '-m',
+        '',
+        '--range',
+        '## Old Section...end of old',
+      ]);
+
+      expect(mockReplaceMarkdown).toHaveBeenCalledWith(
+        expect.anything(),
+        'b55c9c91-384d-452b-81db-d1ef79372b75',
+        '',
+        { range: '## Old Section...end of old', allowDeletingContent: false },
+      );
+      expect(stdoutSpy).toHaveBeenCalledWith('Page content replaced.\n');
+    });
+
+    it('fails with empty -m when no --range is set (would wipe entire page)', async () => {
+      const cmd = editPageCommand();
+      await cmd.parseAsync([
+        'node',
+        'test',
+        'b55c9c91384d452b81dbd1ef79372b75',
+        '-m',
+        '',
+      ]);
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const stderrOutput = stderrSpy.mock.calls
+        .map((c) => String(c[0]))
+        .join('');
+      expect(stderrOutput).toContain(
+        'Empty content would wipe the entire page',
+      );
+      expect(mockReplaceMarkdown).not.toHaveBeenCalled();
+    });
+  });
+
   describe('stdin content', () => {
     it('throws CliError when no -m and stdin is TTY', async () => {
       Object.defineProperty(process.stdin, 'isTTY', {


### PR DESCRIPTION
## Summary

E2E testing found that agents couldn't delete page sections because empty `-m ""` was rejected by the CLI's validation. This fix allows empty `-m ""` to pass through to the Notion API when `--range` is set, enabling section deletion with `notion edit-page <id> --range "selector" -m "" --allow-deleting-content`. Empty `-m` without `--range` is still rejected to prevent accidental full-page wipes. Also documents table HTML format, code block selector disambiguation, and section deletion patterns in the agent docs.