### PR TITLE
feat: add notion archive command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ notion ls
 | `notion edit-page <id\|url> -m <markdown>` | Replace entire page content |
 | `notion create-page --parent <id\|url> --title <title>` | Create a new page, prints URL |
 | `notion update <id\|url> --prop "Name=Value"` | Update properties on a page |
+| `notion archive <id\|url>` | Archive (trash) a page |
 | `notion completion bash\|zsh\|fish` | Install shell tab completion |
 
 ### `notion db query` flags

--- a/docs/FEATURE-PARITY.md
+++ b/docs/FEATURE-PARITY.md
@@ -20,7 +20,7 @@
 | Page properties | Read + write via `update --prop` | Full read + write (update any property) | ✅ Parity |
 | Move pages | - | Batch move to any parent | Gap |
 | Duplicate pages | - | Duplicate with async content copy | Gap |
-| Archive/delete | - | Trash pages | Gap |
+| Archive/delete | `archive` | Trash pages | ✅ Parity |
 | Database create | - | SQL DDL `CREATE TABLE` syntax | Gap |
 | Database schema update | Read-only schema | `ADD/DROP/RENAME/ALTER COLUMN` via DDL | Gap |
 | Database views | - | Create + update 10 view types with DSL | Gap |
@@ -51,11 +51,10 @@ These gaps directly limit what an AI agent can accomplish through the CLI compar
 **CLI:** `notion create-page --parent <db-id> --title "Task" --prop "Status=To Do"` — auto-detects database vs page parent. Supports `--icon` and `--cover`.
 **Status:** Shipped in v0.8.0.
 
-#### 3. Archive / trash pages
+#### 3. ✅ Archive / trash pages (shipped v0.9.0)
 **MCP:** `update-page` with property changes or page operations; `update_data_source` with `in_trash: true`.
-**CLI:** No equivalent.
-**Why third:** Agents need to clean up after themselves — archive completed tasks, delete draft pages.
-**Suggested command:** `notion archive <id>` / `notion delete <id>`
+**CLI:** `notion archive <id>` — archives (trashes) a page. Supports `--json` for full page output.
+**Status:** Shipped in v0.9.0.
 
 #### 4. Search filters (date range, creator)
 **MCP:** `created_date_range` (start/end dates), `created_by_user_ids` filter, scoped search within page/database/teamspace.

--- a/docs/README.agents.md
+++ b/docs/README.agents.md
@@ -120,3 +120,20 @@ notion update "$PAGE_ID" --prop "Status=Done" --json
 | `date` | `--prop "Due=2024-12-25"` or `--prop "Range=2024-01-01,2024-01-31"` |
 
 Required integration capabilities: **Read content**, **Update content**
+
+### `notion archive <id|url>`
+
+Archive (trash) a Notion page.
+
+```bash
+# Archive a page by ID
+notion archive "$PAGE_ID"
+
+# Archive a page by URL
+notion archive "https://www.notion.so/My-Page-b55c9c91384d452b81dbd1ef79372b75"
+
+# Output the full updated page object as JSON
+notion archive "$PAGE_ID" --json
+```
+
+Required integration capabilities: **Read content**, **Update content**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import { appendCommand } from './commands/append.js';
+import { archiveCommand } from './commands/archive.js';
 import { authDefaultAction } from './commands/auth/index.js';
 import { loginCommand } from './commands/auth/login.js';
 import { logoutCommand } from './commands/auth/logout.js';
@@ -110,6 +111,7 @@ program.addCommand(appendCommand());
 program.addCommand(createPageCommand());
 program.addCommand(editPageCommand());
 program.addCommand(updateCommand());
+program.addCommand(archiveCommand());
 
 // --- Database ---
 const dbCmd = new Command('db').description('Database operations');

--- a/src/commands/archive.ts
+++ b/src/commands/archive.ts
@@ -1,0 +1,39 @@
+import { Command } from 'commander';
+import { resolveToken } from '../config/token.js';
+import { withErrorHandling } from '../errors/error-handler.js';
+import { createNotionClient } from '../notion/client.js';
+import { parseNotionId, toUuid } from '../notion/url-parser.js';
+import { formatJSON, getOutputMode } from '../output/format.js';
+import { reportTokenSource } from '../output/stderr.js';
+
+export function archiveCommand(): Command {
+  const cmd = new Command('archive');
+
+  cmd
+    .description('archive (trash) a Notion page')
+    .argument('<id/url>', 'Notion page ID or URL')
+    .action(
+      withErrorHandling(async (idOrUrl: string) => {
+        const { token, source } = await resolveToken();
+        reportTokenSource(source);
+        const client = createNotionClient(token);
+
+        const id = parseNotionId(idOrUrl);
+        const uuid = toUuid(id);
+
+        const updatedPage = await client.pages.update({
+          page_id: uuid,
+          archived: true,
+        });
+
+        const mode = getOutputMode();
+        if (mode === 'json') {
+          process.stdout.write(`${formatJSON(updatedPage)}\n`);
+        } else {
+          process.stdout.write('Page archived.\n');
+        }
+      }),
+    );
+
+  return cmd;
+}

--- a/tests/commands/archive.test.ts
+++ b/tests/commands/archive.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPagesUpdate = vi.fn();
+
+vi.mock('../../src/config/token.js', () => ({
+  resolveToken: vi
+    .fn()
+    .mockResolvedValue({ token: 'test-token', source: 'env' }),
+}));
+
+vi.mock('../../src/output/stderr.js', () => ({
+  reportTokenSource: vi.fn(),
+}));
+
+vi.mock('../../src/notion/client.js', () => ({
+  createNotionClient: vi.fn(() => ({
+    pages: { update: mockPagesUpdate },
+  })),
+}));
+
+import { archiveCommand } from '../../src/commands/archive.js';
+import { setOutputMode } from '../../src/output/format.js';
+
+describe('archiveCommand', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  const fakePage = {
+    id: 'b55c9c91-384d-452b-81db-d1ef79372b75',
+    archived: true,
+    object: 'page',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setOutputMode('auto');
+    mockPagesUpdate.mockResolvedValue(fakePage);
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    setOutputMode('auto');
+  });
+
+  it('calls client.pages.update with archived: true', async () => {
+    const cmd = archiveCommand();
+    await cmd.parseAsync(['node', 'test', 'b55c9c91384d452b81dbd1ef79372b75']);
+
+    expect(mockPagesUpdate).toHaveBeenCalledWith({
+      page_id: 'b55c9c91-384d-452b-81db-d1ef79372b75',
+      archived: true,
+    });
+  });
+
+  it('outputs "Page archived." in text mode', async () => {
+    const cmd = archiveCommand();
+    await cmd.parseAsync(['node', 'test', 'b55c9c91384d452b81dbd1ef79372b75']);
+
+    expect(stdoutSpy).toHaveBeenCalledWith('Page archived.\n');
+  });
+
+  it('outputs JSON in json mode', async () => {
+    setOutputMode('json');
+    const cmd = archiveCommand();
+    await cmd.parseAsync(['node', 'test', 'b55c9c91384d452b81dbd1ef79372b75']);
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const parsed = JSON.parse(output);
+    expect(parsed).toEqual(fakePage);
+  });
+});


### PR DESCRIPTION
Agents and users can now archive (trash) pages with `notion archive <id|url>`, closing Gap #3 from the feature parity analysis.

Supports `--json` for full page object output.