### PR TITLE
feat: add --sort flag to search and ls commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ notion ls
 | `notion auth status` | Show current auth state |
 | `notion auth list` | List all saved profiles |
 | `notion auth use <name>` | Switch the active profile |
-| `notion search <query>` | Search pages and databases by title |
-| `notion ls` | List all accessible pages and databases |
+| `notion search <query>` | Search pages and databases by title (`--sort asc\|desc`) |
+| `notion ls` | List all accessible pages and databases (`--sort asc\|desc`) |
 | `notion open <id\|url>` | Open a page in your browser |
 | `notion read <id\|url>` | Read a page as markdown |
 | `notion db schema <id\|url>` | Show database property schema and valid values |
@@ -101,6 +101,15 @@ notion ls
 | `notion update <id\|url> --prop "Name=Value"` | Update properties on a page |
 | `notion archive <id\|url>` | Archive (trash) a page |
 | `notion completion bash\|zsh\|fish` | Install shell tab completion |
+
+### `notion search` / `notion ls` flags
+
+| Flag | Example | Description |
+|------|---------|-------------|
+| `--sort` | `--sort desc` | Sort by last edited time (`asc` or `desc`) |
+| `--type` | `--type page` | Filter by object type (`page` or `database`) |
+| `--cursor` | `--cursor <cursor>` | Pagination cursor from a previous `--next` hint |
+| `--json` | `--json` | Force JSON output |
 
 ### `notion db query` flags
 

--- a/docs/FEATURE-PARITY.md
+++ b/docs/FEATURE-PARITY.md
@@ -13,7 +13,7 @@
 
 | Area | CLI | MCP | Parity |
 |------|-----|-----|--------|
-| Search | Basic keyword | Semantic + AI + connected sources + date/creator filters | Partial |
+| Search | Keyword + sort by last edited | Semantic + AI + connected sources + date/creator filters | Partial |
 | Page read | Markdown via API | Markdown + discussions + transcripts | Partial |
 | Page create | Under pages only | Under pages, databases, data sources; batch; templates; icon/cover | Partial |
 | Page edit | Surgical replace via `--range` | Search-and-replace (multi-op), full replace, template apply, verification | Partial |
@@ -56,11 +56,11 @@ These gaps directly limit what an AI agent can accomplish through the CLI compar
 **CLI:** `notion archive <id>` — archives (trashes) a page. Supports `--json` for full page output.
 **Status:** Shipped in v0.9.0.
 
-#### 4. Search filters (date range, creator)
+#### 4. Search filters (date range, creator) — partially addressed
 **MCP:** `created_date_range` (start/end dates), `created_by_user_ids` filter, scoped search within page/database/teamspace.
-**CLI:** Keyword-only search with `--type` filter.
-**Why important:** Agents searching for "recent" items or "my tasks" need date and creator filters to get relevant results without scanning everything.
-**Suggested flags:** `--created-after`, `--created-before`, `--created-by`
+**CLI:** Keyword search with `--type` filter and `--sort asc|desc` (sort by last edited time).
+**Status:** `--sort` added in v0.9.0. Date range and creator filters are **blocked** — the MCP server uses an internal Notion API not accessible to integration tokens. The public search endpoint only supports `sort` as an additional parameter.
+**Remaining gap:** `--created-after`, `--created-before`, `--created-by` cannot be implemented with the public API.
 
 ### Tier 2 - Medium Impact (power-user and advanced agent workflows)
 

--- a/docs/README.agents.md
+++ b/docs/README.agents.md
@@ -81,6 +81,27 @@ curl -fsSL https://raw.githubusercontent.com/andrzejchm/notion-cli/main/docs/ski
 
 ## Commands Reference
 
+### `notion search <query>` / `notion ls`
+
+Search or list pages and databases. Both commands support:
+
+```bash
+# Sort results by last edited time
+notion search "meeting notes" --sort desc
+notion ls --sort asc
+
+# Filter by type
+notion search "Q1" --type page
+notion ls --type database
+```
+
+| Flag | Description |
+|------|-------------|
+| `--sort <asc\|desc>` | Sort by last edited time |
+| `--type <page\|database>` | Filter by object type |
+| `--cursor <cursor>` | Pagination cursor from a previous `--next` hint |
+| `--json` | Force JSON output |
+
 ### `notion update <id|url>`
 
 Update properties on any Notion page (standalone or database entry).

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -46,6 +46,16 @@ export function lsCommand(): Command {
       },
     )
     .option(
+      '--sort <direction>',
+      'sort by last edited time (asc or desc)',
+      (val) => {
+        if (val !== 'asc' && val !== 'desc') {
+          throw new Error('--sort must be "asc" or "desc"');
+        }
+        return val as 'asc' | 'desc';
+      },
+    )
+    .option(
       '--cursor <cursor>',
       'start from this pagination cursor (from a previous --next hint)',
     )
@@ -54,6 +64,7 @@ export function lsCommand(): Command {
       withErrorHandling(
         async (opts: {
           type?: 'page' | 'database';
+          sort?: 'asc' | 'desc';
           cursor?: string;
           json?: boolean;
         }) => {
@@ -66,6 +77,12 @@ export function lsCommand(): Command {
           const notion = createNotionClient(token);
 
           const response = await notion.search({
+            sort: opts.sort
+              ? {
+                  timestamp: 'last_edited_time',
+                  direction: opts.sort === 'asc' ? 'ascending' : 'descending',
+                }
+              : undefined,
             start_cursor: opts.cursor,
             page_size: 20,
           });

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -52,6 +52,16 @@ export function searchCommand(): Command {
       },
     )
     .option(
+      '--sort <direction>',
+      'sort by last edited time (asc or desc)',
+      (val) => {
+        if (val !== 'asc' && val !== 'desc') {
+          throw new Error('--sort must be "asc" or "desc"');
+        }
+        return val as 'asc' | 'desc';
+      },
+    )
+    .option(
       '--cursor <cursor>',
       'start from this pagination cursor (from a previous --next hint)',
     )
@@ -60,7 +70,12 @@ export function searchCommand(): Command {
       withErrorHandling(
         async (
           query: string,
-          opts: { type?: 'page' | 'database'; cursor?: string; json?: boolean },
+          opts: {
+            type?: 'page' | 'database';
+            sort?: 'asc' | 'desc';
+            cursor?: string;
+            json?: boolean;
+          },
         ) => {
           if (opts.json) {
             setOutputMode('json');
@@ -74,6 +89,12 @@ export function searchCommand(): Command {
             query,
             filter: opts.type
               ? { property: 'object', value: toSdkFilterValue(opts.type) }
+              : undefined,
+            sort: opts.sort
+              ? {
+                  timestamp: 'last_edited_time',
+                  direction: opts.sort === 'asc' ? 'ascending' : 'descending',
+                }
               : undefined,
             start_cursor: opts.cursor,
             page_size: 20,

--- a/tests/commands/ls.test.ts
+++ b/tests/commands/ls.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSearch = vi.fn();
+
+vi.mock('../../src/config/token.js', () => ({
+  resolveToken: vi
+    .fn()
+    .mockResolvedValue({ token: 'test-token', source: 'env' }),
+}));
+
+vi.mock('../../src/output/stderr.js', () => ({
+  reportTokenSource: vi.fn(),
+}));
+
+vi.mock('../../src/notion/client.js', () => ({
+  createNotionClient: vi.fn(() => ({
+    search: mockSearch,
+  })),
+}));
+
+import { lsCommand } from '../../src/commands/ls.js';
+import { setOutputMode } from '../../src/output/format.js';
+
+describe('lsCommand --sort', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  const fakeResponse = {
+    results: [
+      {
+        object: 'page' as const,
+        id: 'page-1',
+        properties: {
+          Name: {
+            type: 'title' as const,
+            title: [{ plain_text: 'Test Page' }],
+          },
+        },
+        last_edited_time: '2026-03-20T10:00:00.000Z',
+        parent: { type: 'workspace', workspace: true },
+      },
+    ],
+    has_more: false,
+    next_cursor: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setOutputMode('auto');
+    mockSearch.mockResolvedValue(fakeResponse);
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    setOutputMode('auto');
+  });
+
+  it('passes sort descending to the API when --sort desc is used', async () => {
+    const cmd = lsCommand();
+    await cmd.parseAsync(['node', 'test', '--sort', 'desc']);
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: {
+          timestamp: 'last_edited_time',
+          direction: 'descending',
+        },
+      }),
+    );
+  });
+
+  it('passes sort ascending to the API when --sort asc is used', async () => {
+    const cmd = lsCommand();
+    await cmd.parseAsync(['node', 'test', '--sort', 'asc']);
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: {
+          timestamp: 'last_edited_time',
+          direction: 'ascending',
+        },
+      }),
+    );
+  });
+
+  it('does not pass sort when --sort is omitted', async () => {
+    const cmd = lsCommand();
+    await cmd.parseAsync(['node', 'test']);
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: undefined,
+      }),
+    );
+  });
+});

--- a/tests/commands/search.test.ts
+++ b/tests/commands/search.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSearch = vi.fn();
+
+vi.mock('../../src/config/token.js', () => ({
+  resolveToken: vi
+    .fn()
+    .mockResolvedValue({ token: 'test-token', source: 'env' }),
+}));
+
+vi.mock('../../src/output/stderr.js', () => ({
+  reportTokenSource: vi.fn(),
+}));
+
+vi.mock('../../src/notion/client.js', () => ({
+  createNotionClient: vi.fn(() => ({
+    search: mockSearch,
+  })),
+}));
+
+import { searchCommand } from '../../src/commands/search.js';
+import { setOutputMode } from '../../src/output/format.js';
+
+describe('searchCommand --sort', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  const fakeResponse = {
+    results: [
+      {
+        object: 'page' as const,
+        id: 'page-1',
+        properties: {
+          Name: {
+            type: 'title' as const,
+            title: [{ plain_text: 'Test Page' }],
+          },
+        },
+        last_edited_time: '2026-03-20T10:00:00.000Z',
+        parent: { type: 'workspace', workspace: true },
+      },
+    ],
+    has_more: false,
+    next_cursor: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setOutputMode('auto');
+    mockSearch.mockResolvedValue(fakeResponse);
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    setOutputMode('auto');
+  });
+
+  it('passes sort descending to the API when --sort desc is used', async () => {
+    const cmd = searchCommand();
+    await cmd.parseAsync(['node', 'test', 'my query', '--sort', 'desc']);
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: {
+          timestamp: 'last_edited_time',
+          direction: 'descending',
+        },
+      }),
+    );
+  });
+
+  it('passes sort ascending to the API when --sort asc is used', async () => {
+    const cmd = searchCommand();
+    await cmd.parseAsync(['node', 'test', 'my query', '--sort', 'asc']);
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: {
+          timestamp: 'last_edited_time',
+          direction: 'ascending',
+        },
+      }),
+    );
+  });
+
+  it('does not pass sort when --sort is omitted', async () => {
+    const cmd = searchCommand();
+    await cmd.parseAsync(['node', 'test', 'my query']);
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: undefined,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Sort search/ls results by last edited time (asc/desc) via `--sort asc` or `--sort desc`. Without the flag, Notion's default relevance ordering is preserved.

This is the only additional search parameter available on the public Notion API — date range and creator filters use an internal API not accessible to integration tokens.