### PR TITLE
feat: add notion move command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ notion ls
 | `notion create-page --parent <id\|url> --title <title>` | Create a new page, prints URL |
 | `notion update <id\|url> --prop "Name=Value"` | Update properties on a page |
 | `notion archive <id\|url>` | Archive (trash) a page |
+| `notion move <ids\|urls...> --to <id\|url>` | Move pages to a new parent page |
+| `notion move <ids\|urls...> --to-db <id\|url>` | Move pages to a database parent |
 | `notion completion bash\|zsh\|fish` | Install shell tab completion |
 
 ### `notion search` / `notion ls` flags

--- a/docs/FEATURE-PARITY.md
+++ b/docs/FEATURE-PARITY.md
@@ -18,7 +18,7 @@
 | Page create | Under pages only | Under pages, databases, data sources; batch; templates; icon/cover | Partial |
 | Page edit | Multi-op `--find`/`--replace`, `--range` | Search-and-replace (multi-op), full replace, template apply, verification | Partial |
 | Page properties | Read + write via `update --prop` | Full read + write (update any property) | ✅ Parity |
-| Move pages | - | Batch move to any parent | Gap |
+| Move pages | `move --to` / `--to-db` | Batch move to any parent | ✅ Parity |
 | Duplicate pages | - | Duplicate with async content copy | Gap |
 | Archive/delete | `archive` | Trash pages | ✅ Parity |
 | Database create | `db create --prop` syntax | SQL DDL `CREATE TABLE` syntax | Partial |
@@ -74,11 +74,10 @@ These gaps directly limit what an AI agent can accomplish through the CLI compar
 **CLI:** `notion db create --parent <id> --title "Tasks" --prop "Status:select:To Do,Done"` — supports title, rich_text, number, select, multi_select, status, date, checkbox, url, email, phone_number, people, files, created_time, last_edited_time. Relation, rollup, formula, and unique_id are not supported (too complex for CLI flags).
 **Status:** Shipped in v0.10.0.
 
-#### 7. Move pages
+#### 7. ✅ Move pages (shipped v0.11.0)
 **MCP:** Batch move up to 100 pages/databases to a new parent (page, database, data source, or workspace).
-**CLI:** No equivalent.
-**Why:** Reorganizing content (moving completed items to archive, restructuring projects) is a common agent task.
-**Suggested command:** `notion move <id...> --to <parent-id>`
+**CLI:** `notion move <ids...> --to <page-id>` or `notion move <ids...> --to-db <database-id>`. Supports multiple page IDs as variadic arguments.
+**Status:** Shipped in v0.11.0.
 
 #### 8. Update database schema
 **MCP:** `ADD COLUMN`, `DROP COLUMN`, `RENAME COLUMN`, `ALTER COLUMN SET` via DDL.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { dbSchemaCommand } from './commands/db/schema.js';
 import { editPageCommand } from './commands/edit-page.js';
 import { initCommand } from './commands/init.js';
 import { lsCommand } from './commands/ls.js';
+import { moveCommand } from './commands/move.js';
 import { openCommand } from './commands/open.js';
 import { profileListCommand } from './commands/profile/list.js';
 import { profileRemoveCommand } from './commands/profile/remove.js';
@@ -113,6 +114,7 @@ program.addCommand(createPageCommand());
 program.addCommand(editPageCommand());
 program.addCommand(updateCommand());
 program.addCommand(archiveCommand());
+program.addCommand(moveCommand());
 
 // --- Database ---
 const dbCmd = new Command('db').description('Database operations');

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -1,0 +1,85 @@
+import { Command } from 'commander';
+import { resolveToken } from '../config/token.js';
+import { CliError } from '../errors/cli-error.js';
+import { ErrorCodes } from '../errors/codes.js';
+import { withErrorHandling } from '../errors/error-handler.js';
+import { createNotionClient } from '../notion/client.js';
+import { parseNotionId, toUuid } from '../notion/url-parser.js';
+import { formatJSON, getOutputMode } from '../output/format.js';
+import { reportTokenSource } from '../output/stderr.js';
+import { resolveDataSourceId } from '../services/database.service.js';
+
+interface MoveOpts {
+  to?: string;
+  toDb?: string;
+}
+
+export function moveCommand(): Command {
+  const cmd = new Command('move');
+
+  cmd
+    .description('move pages to a new parent')
+    .argument('<ids/urls...>', 'Notion page IDs or URLs to move')
+    .option('--to <id/url>', 'target page parent ID or URL')
+    .option(
+      '--to-db <id/url>',
+      'target database parent ID or URL (resolves to data source)',
+    )
+    .action(
+      withErrorHandling(async (idsOrUrls: string[], opts: MoveOpts) => {
+        if (!opts.to && !opts.toDb) {
+          throw new CliError(
+            ErrorCodes.INVALID_ARG,
+            'No target parent specified.',
+            'Provide --to <page-id> or --to-db <database-id>',
+          );
+        }
+
+        if (opts.to && opts.toDb) {
+          throw new CliError(
+            ErrorCodes.INVALID_ARG,
+            'Cannot specify both --to and --to-db.',
+            'Provide only one: --to <page-id> or --to-db <database-id>',
+          );
+        }
+
+        const { token, source } = await resolveToken();
+        reportTokenSource(source);
+        const client = createNotionClient(token);
+
+        let parent:
+          | { type: 'page_id'; page_id: string }
+          | { type: 'data_source_id'; data_source_id: string };
+
+        if (opts.toDb) {
+          const dsId = await resolveDataSourceId(client, opts.toDb);
+          parent = { type: 'data_source_id', data_source_id: dsId };
+        } else if (opts.to) {
+          const targetId = toUuid(parseNotionId(opts.to));
+          parent = { type: 'page_id', page_id: targetId };
+        } else {
+          // Unreachable — validated above
+          throw new CliError(
+            ErrorCodes.INVALID_ARG,
+            'No target parent specified.',
+          );
+        }
+
+        const results = [];
+        for (const idOrUrl of idsOrUrls) {
+          const uuid = toUuid(parseNotionId(idOrUrl));
+          const result = await client.pages.move({ page_id: uuid, parent });
+          results.push(result);
+        }
+
+        const mode = getOutputMode();
+        if (mode === 'json') {
+          process.stdout.write(`${formatJSON(results)}\n`);
+        } else {
+          process.stdout.write(`Moved ${results.length} page(s).\n`);
+        }
+      }),
+    );
+
+  return cmd;
+}

--- a/tests/commands/move.test.ts
+++ b/tests/commands/move.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPagesMove = vi.fn();
+const mockDataSourcesRetrieve = vi.fn();
+const mockDatabasesRetrieve = vi.fn();
+
+vi.mock('../../src/config/token.js', () => ({
+  resolveToken: vi
+    .fn()
+    .mockResolvedValue({ token: 'test-token', source: 'env' }),
+}));
+
+vi.mock('../../src/output/stderr.js', () => ({
+  reportTokenSource: vi.fn(),
+}));
+
+vi.mock('../../src/notion/client.js', () => ({
+  createNotionClient: vi.fn(() => ({
+    pages: { move: mockPagesMove },
+    dataSources: { retrieve: mockDataSourcesRetrieve },
+    databases: { retrieve: mockDatabasesRetrieve },
+  })),
+}));
+
+import { moveCommand } from '../../src/commands/move.js';
+import { setOutputMode } from '../../src/output/format.js';
+
+describe('moveCommand', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  const fakeMovedPage = {
+    id: 'b55c9c91-384d-452b-81db-d1ef79372b75',
+    object: 'page',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setOutputMode('auto');
+    mockPagesMove.mockResolvedValue(fakeMovedPage);
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    setOutputMode('auto');
+  });
+
+  it('moves a single page to a page parent', async () => {
+    const cmd = moveCommand();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'b55c9c91384d452b81dbd1ef79372b75',
+      '--to',
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    ]);
+
+    expect(mockPagesMove).toHaveBeenCalledWith({
+      page_id: 'b55c9c91-384d-452b-81db-d1ef79372b75',
+      parent: {
+        type: 'page_id',
+        page_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      },
+    });
+  });
+
+  it('moves multiple pages to a page parent', async () => {
+    const cmd = moveCommand();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'b55c9c91384d452b81dbd1ef79372b75',
+      'c66d0d02495e563c92ece2f80483c860',
+      '--to',
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    ]);
+
+    expect(mockPagesMove).toHaveBeenCalledTimes(2);
+    expect(mockPagesMove).toHaveBeenCalledWith({
+      page_id: 'b55c9c91-384d-452b-81db-d1ef79372b75',
+      parent: {
+        type: 'page_id',
+        page_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      },
+    });
+    expect(mockPagesMove).toHaveBeenCalledWith({
+      page_id: 'c66d0d02-495e-563c-92ec-e2f80483c860',
+      parent: {
+        type: 'page_id',
+        page_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      },
+    });
+  });
+
+  it('moves a page to a database parent via --to-db', async () => {
+    mockDataSourcesRetrieve.mockRejectedValueOnce(new Error('not found'));
+    mockDatabasesRetrieve.mockResolvedValueOnce({
+      data_sources: [{ id: 'resolved-ds-id-0000-0000-000000000000' }],
+    });
+
+    const cmd = moveCommand();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'b55c9c91384d452b81dbd1ef79372b75',
+      '--to-db',
+      'dbdbdbdb-1111-2222-3333-444444444444',
+    ]);
+
+    expect(mockPagesMove).toHaveBeenCalledWith({
+      page_id: 'b55c9c91-384d-452b-81db-d1ef79372b75',
+      parent: {
+        type: 'data_source_id',
+        data_source_id: 'resolved-ds-id-0000-0000-000000000000',
+      },
+    });
+  });
+
+  it('errors when neither --to nor --to-db is provided', async () => {
+    const cmd = moveCommand();
+    await cmd.parseAsync(['node', 'test', 'b55c9c91384d452b81dbd1ef79372b75']);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const stderrOutput = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stderrOutput).toContain('--to');
+    expect(stderrOutput).toContain('--to-db');
+  });
+
+  it('errors when both --to and --to-db are provided', async () => {
+    const cmd = moveCommand();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'b55c9c91384d452b81dbd1ef79372b75',
+      '--to',
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      '--to-db',
+      'dbdbdbdb-1111-2222-3333-444444444444',
+    ]);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const stderrOutput = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stderrOutput).toContain('--to');
+    expect(stderrOutput).toContain('--to-db');
+  });
+
+  it('outputs "Moved 1 page(s)." in text mode', async () => {
+    const cmd = moveCommand();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'b55c9c91384d452b81dbd1ef79372b75',
+      '--to',
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    ]);
+
+    expect(stdoutSpy).toHaveBeenCalledWith('Moved 1 page(s).\n');
+  });
+
+  it('outputs "Moved 2 page(s)." for multiple pages', async () => {
+    const cmd = moveCommand();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'b55c9c91384d452b81dbd1ef79372b75',
+      'c66d0d02495e563c92ece2f80483c860',
+      '--to',
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    ]);
+
+    expect(stdoutSpy).toHaveBeenCalledWith('Moved 2 page(s).\n');
+  });
+
+  it('outputs JSON array in json mode', async () => {
+    setOutputMode('json');
+    const cmd = moveCommand();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'b55c9c91384d452b81dbd1ef79372b75',
+      '--to',
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    ]);
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const parsed = JSON.parse(output);
+    expect(parsed).toEqual([fakeMovedPage]);
+  });
+});


### PR DESCRIPTION
Adds `notion move <ids...> --to <parent>` to reparent pages, closing Gap #7 from the feature parity tracker. Supports page parents (`--to`) and database parents (`--to-db`, which resolves to a data source ID). Multiple page IDs accepted as variadic arguments.